### PR TITLE
Support ReSharper Out-of-Process mode

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4

--- a/Sources/ReCommendedExtension/Zone.cs
+++ b/Sources/ReCommendedExtension/Zone.cs
@@ -1,7 +1,10 @@
 ﻿using JetBrains.Application.BuildScript.Application.Zones;
 using JetBrains.Application.Environment;
+using JetBrains.Platform.VisualStudio.Protocol.BuildScript;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.Xaml;
+using JetBrains.VsIntegration.Env;
+using JetBrains.VsIntegration.Zones;
 using ReCommendedExtension;
 
 namespace ReCommendedExtension
@@ -36,10 +39,28 @@ namespace ReCommendedExtension
 
 namespace ExtensionActivator
 {
+#if RIDER
+  [ZoneActivator]
+  [ZoneMarker]
+  public sealed class ReCommendedExtensionActivator : IActivate<IReCommendedExtensionZone>
+  {
+    public bool ActivatorEnabled() => true;
+  }
+#endif
+
+
+#if RESHARPER
+    /// Activator for InProcess mode
     [ZoneActivator]
-    [ZoneMarker]
-    public sealed class ReCommendedExtensionActivator : IActivate<IReCommendedExtensionZone>
+    [ZoneMarker(typeof(IVisualStudioFrontendEnvZone))]
+    public sealed class ReCommendedExtensionActivator(VisualStudioProtocolConnector protocolConnector) : IActivateDynamic<IReCommendedExtensionZone>
     {
-        public bool ActivatorEnabled() => true;
+        public bool ActivatorEnabled() => !protocolConnector.IsOutOfProcess;
     }
+
+    /// Activator for Out of Process mode
+    [ZoneActivator]
+    [ZoneMarker(typeof(IVisualStudioBackendOutOfProcessEnvZone))]
+    public sealed class ReCommendedExtensionActivatorOOP : IActivate<IReCommendedExtensionZone>;
+#endif
 }


### PR DESCRIPTION
Currently, the zone activator activates PSI-related zones in Visual
Studio Side unconditionally, which renders ReSharper OOP mode useless.
Code analysis will be performed on both sides in this case.

Disable the activator in Visual Studio when the product is out of
process mode, and add an additional activator for the separate process
mode. Additional activator is reponsible for activation of the extension
in the separate process.

I also added an editorconfig file because I have different indents in VS.
I didn't want to submit code with a different style.